### PR TITLE
repo-review: justify nosec and use bborbe/errors in CatchPanic at 5c02898

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 * MINOR version when you add functionality in a backwards-compatible manner, and
 * PATCH version when you make backwards-compatible bug fixes.
 
+## Unreleased
+
+- fix: justify the #nosec G118 directive in ContextWithSig
+- fix: CatchPanic returns bborbe/errors instead of fmt.Errorf
+
 ## v1.9.33
 
 - update Go to 1.26.5 and update dependencies

--- a/run_context-with-sig.go
+++ b/run_context-with-sig.go
@@ -17,7 +17,9 @@ import (
 // It listens for SIGINT and SIGTERM signals and cancels the returned context when any of these signals are received.
 // This is useful for graceful shutdown of long-running processes.
 func ContextWithSig(ctx context.Context) context.Context {
-	ctxWithCancel, cancel := context.WithCancel(ctx) // #nosec G118
+	// #nosec G118 -- the cancel func is not leaked: the goroutine below owns it
+	// and defers it, so it runs on signal receipt or on parent-ctx cancellation.
+	ctxWithCancel, cancel := context.WithCancel(ctx)
 	go func() {
 		defer cancel()
 

--- a/run_panic.go
+++ b/run_panic.go
@@ -6,7 +6,8 @@ package run
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/bborbe/errors"
 )
 
 // CatchPanic wraps the given function to recover from panics and convert them to errors.
@@ -15,7 +16,7 @@ func CatchPanic(fn Func) Func {
 	return func(ctx context.Context) (err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				err = fmt.Errorf("catch panic: %v", r)
+				err = errors.Errorf(ctx, "catch panic: %v", r)
 			}
 		}()
 		return fn(ctx)


### PR DESCRIPTION
Repo review at `5c02898`. **248 mechanical findings from 74 rules → 2 fixed.**

## Fixed

**M1 — `#nosec G118` with no justification** (`run_context-with-sig.go:19`). A bare `nosec` is unreviewable: a reader cannot tell whether the suppression is sound. It is — the goroutine below owns the `cancel` func and defers it, so it runs on signal receipt or on parent-ctx cancellation. Now recorded in the code.

**S1 — `CatchPanic` built its error with `fmt.Errorf`** (`run_panic.go:17`) while the rest of the package uses `bborbe/errors` and has `ctx` in scope. Converted to `errors.Errorf(ctx, …)`.

`%v` is retained rather than `%w` deliberately: `recover()` returns `any`, not an `error`, so there is nothing to unwrap.

## Refuted — 246 of 248, and this repo is why the rules exist

**8 × `channel-closed-by-sender-only` + 9 × `no-raw-go-func`** fire across `run_concurrent-runner.go`, `run_runner.go`, `run_trigger.go`, `run_background-runner.go`. This is a **concurrency library** — orchestrating goroutines and channels is its entire purpose, so it is the exemplar these rules describe rather than a violator of them.

Read rather than assumed. `concurrentRunner` in particular is careful in ways worth recording:

- `Close()` takes the mutex and `select`s on `c.closed` before closing, so a double `Close()` returns an error instead of panicking.
- `Add()` guards the send with the same mutex + `select`, so it can never send on a closed channel.
- `Run()` defers `wg.Wait()` **before** `close(limit)` / `close(errs)`, so no goroutine is still running when the channels close.
- The send on the unbuffered `errs` is itself `select`-guarded against `<-ctx.Done()`, and `CancelOnFirstError` cancels when the consumer returns — so a producer can never block forever on a channel nobody is reading.

That last one is the interesting case: an unbuffered error channel closed in a defer is exactly the shape that deadlocks when written naively. It does not here.

The remainder fall to the standing triage table plus naming/shape suggestions (`new-prefix-constructor-naming`, `list-type-name`, `func-type-name`, `small-interfaces-1-2-methods`) that identify no defect.

## Verification

`make precommit` green — **98.8% coverage**, 0 lint, 0 vulns. Findings counted after dropping generated sources per `commands/code-review.md` Step 1.